### PR TITLE
Added cmake

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4-alpine
 
-RUN apk add --no-cache build-base gcc bash
+RUN apk add --no-cache build-base gcc bash cmake
 
 RUN gem install jekyll
 


### PR DESCRIPTION
`commonmarker` needed `cmake`:

```
jekyll_1  | Installing commonmarker 0.17.6 with native extensions
jekyll_1  | Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
jekyll_1  | 
jekyll_1  | current directory:
jekyll_1  | /usr/local/bundle/gems/commonmarker-0.17.6/ext/commonmarker
jekyll_1  | /usr/local/bin/ruby -r ./siteconf20180314-8-1urdadg.rb extconf.rb
jekyll_1  | checking for cmake... no
```