### PR TITLE
dockerfile - add nodejs (support for execjs).

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.4-alpine
 
-RUN apk add --no-cache build-base gcc bash cmake
+RUN apk add --no-cache build-base gcc bash cmake nodejs
 
 RUN gem install jekyll
 


### PR DESCRIPTION
Related: https://github.com/jekyll/jekyll/issues/2327.
Size: 266 MB to 308 MB

It's a 42 MB increase, so it's understandable if you want to reject this PR.

```
$ docker run --rm -p 80:4000 -v $(pwd):/site bretfisher/jekyll-serve
Fetching gem metadata from https://rubygems.org/...........
Using public_suffix 3.0.2
Using addressable 2.5.2
Using bundler 1.16.2
Using colorator 1.1.0
Using concurrent-ruby 1.0.5
Fetching cssminify2 2.0.1
Installing cssminify2 2.0.1
Using eventmachine 1.2.7
Using http_parser.rb 0.6.0
Using em-websocket 0.5.1
Fetching execjs 2.7.0
Installing execjs 2.7.0
Using ffi 1.9.25
Using forwardable-extended 2.6.0
Fetching htmlcompressor 0.4.0
Installing htmlcompressor 0.4.0
Using i18n 0.9.5
Using rb-fsevent 0.10.3
Using rb-inotify 0.9.10
Using sass-listen 4.0.0
Using sass 3.5.6
Using jekyll-sass-converter 1.5.2
Using ruby_dep 1.5.0
Using listen 3.1.5
Using jekyll-watch 2.0.0
Using kramdown 1.17.0
Using liquid 4.0.0
Using mercenary 0.3.6
Using pathutil 0.16.1
Using rouge 3.1.1
Using safe_yaml 1.0.4
Using jekyll 3.8.3
Fetching uglifier 3.2.0
Installing uglifier 3.2.0
Fetching jekyll-minifier 0.1.6
Installing jekyll-minifier 0.1.6
Bundle complete! 2 Gemfile dependencies, 31 gems now installed.
Bundled gems are installed into `/usr/local/bundle`
Configuration file: /site/_config.yml
jekyll 3.8.3 | Error:  Could not find a JavaScript runtime. See https://github.com/rails/execjs for a list of available runtimes.
```