### PR TITLE
add git for gh-pages gem support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.5-alpine as jekyll-base
 
-RUN apk add --no-cache build-base gcc bash cmake
+RUN apk add --no-cache build-base gcc bash cmake && apk add git
 
 RUN gem install jekyll
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.5-alpine as jekyll-base
 
-RUN apk add --no-cache build-base gcc bash cmake && apk add git
+RUN apk add --no-cache build-base gcc bash cmake git
 
 RUN gem install jekyll
 


### PR DESCRIPTION
Git needs to be installed to use the [gh-pages gem](https://github.com/github/pages-gem/blob/06ff297fa077969851f9fd6f00ec5da8d1c33a60/github-pages.gemspec#L19).