### PR TITLE
Add `git` to installed package set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM ruby:2.7-alpine
 
-RUN apk add --no-cache build-base gcc bash cmake
+RUN apk add --no-cache build-base gcc bash cmake git
 
 # install both bundler 1.x and 2.x
 RUN gem install bundler -v "~>1.0" && gem install bundler jekyll


### PR DESCRIPTION
When using to preview Github Pages with the `github-pages` `jekyll`
plugin, attempts will be made to run to run `git rev-parse HEAD`. This
requires `git`.