### PR TITLE
added the jekyll watch flag

### DIFF
--- a/Dockerfile.serve
+++ b/Dockerfile.serve
@@ -8,4 +8,4 @@ COPY docker-entrypoint.sh /usr/local/bin/
 # on every container start, check if Gemfile exists and warn if it's missing
 ENTRYPOINT [ "docker-entrypoint.sh" ]
 
-CMD [ "bundle", "exec", "jekyll", "serve", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]
+CMD [ "bundle", "exec", "jekyll", "serve", "--watch", "--force_polling", "-H", "0.0.0.0", "-P", "4000" ]


### PR DESCRIPTION
Hi,

Stumbled on your very useful utility when testing setup of a github pages page. Maybe I've misunderstood the purpose of your "serve" but for my use case it became a lot more helpful with the --watch flag added, allowing me to get instant feedback on changes in the source. 

Another option is ofc to add a third image, Dockerfile.watch.. or maybe there are other elegant options.

Thanks again for sharing your work.