### PR TITLE
Parametric ruby version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ruby:alpine as jekyll
+ARG RUBY_VERSION=3.0
+
+FROM ruby:${RUBY_VERSION}-alpine as jekyll
 
 RUN apk add --no-cache build-base gcc bash cmake git
 


### PR DESCRIPTION
The `Dockerfile` uses `ruby:alpine` which defaults to the latest version. This can break compatibility with gems overnight.

This PR allows you to specify the ruby version to use when building the image:

```
docker build --build-arg RUBY_VERSION=2.7 ...
```