### PR TITLE
Match internal and external port to 4000 for sanity

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     volumes:
       - .:/site
     ports:
-      - '8080:4000'
+      - '4000:4000'


### PR DESCRIPTION
Closes #50

This was a simple bug, and I realized were two ways to solve it:
- Declare an extra enviorment variable for host port and set the dockerfile accordingly
- Map both the container and host ports to 4000.

I chose the second hassle-free solution.

p.s: The solution was drafted without the consulation of the maintainer 😨 , feel free to make any suggestions.