### PR TITLE
move back to ruby 3.1

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.jekyll-cache
+_site
+.github
+.git
+README.md

--- a/.github/workflows/call-docker-build.yaml
+++ b/.github/workflows/call-docker-build.yaml
@@ -58,7 +58,7 @@ jobs:
 
     needs: build-jekyll-image
 
-    if: github.event_name == 'push'
+    # if: github.event_name == 'push'
 
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.jekyll-cache
+_site

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3-slim-bullseye as jekyll
+FROM ruby:3.1-slim-bullseye as jekyll
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # used in the jekyll-server image, which is FROM this image
 COPY docker-entrypoint.sh /usr/local/bin/
 
-RUN gem install bundler jekyll
+RUN gem update --system && gem install jekyll && gem cleanup
 
 EXPOSE 4000
 
@@ -19,7 +19,7 @@ ENTRYPOINT [ "jekyll" ]
 CMD [ "--help" ]
 
 # build from the image we just built with different metadata
-FROM ghcr.io/bretfisher/jekyll:latest as jekyll-serve
+FROM jekyll as jekyll-serve
 
 # on every container start, check if Gemfile exists and warn if it's missing
 ENTRYPOINT [ "docker-entrypoint.sh" ]


### PR DESCRIPTION
There may be issues with Ruby 3.2 in Jekyll 4.x. I haven't dug in deep, but wanted to provide a 3.1 build to compare to 3.2. Hopefully helping troubleshooting in #82 